### PR TITLE
Fixed issue of "list index out of range"

### DIFF
--- a/face_embedding.py
+++ b/face_embedding.py
@@ -58,6 +58,8 @@ class FaceEmbedding:
                             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                             bounding_boxes, points = self.alignMTCNN.get_bounding_boxes(image=img)
                             faces = self.get_faces(img, bounding_boxes, points, filename)
+                            if(len(faces)==0):
+                                continue
                             extracted.append(faces)
                         with open('extracted_embeddings.pickle','wb') as f:
                             pickle.dump(extracted,f)


### PR DESCRIPTION
In case our model do not detect face from images in peoples folder it create empty list instead of list of dictionaries. so while predicting values it gives error as "list index out of range". By adding these line we will only save details of image if and only if it has detected faces i.e prevention from saving empty list is pickle file.